### PR TITLE
Update CLI docs to reflect how redaction is done

### DIFF
--- a/includes/_cli-generate.md
+++ b/includes/_cli-generate.md
@@ -40,7 +40,7 @@ user$ credhub generate --type password --name '/example-password'
 id: 67fc3def-bbfb-4953-83f8-4ab0682ad675
 name: /example-password
 type: password
-value: 3t6Y2OFP0jQIcLnki1h7p3NtSfDx4l9bamr1ja6R
+value: <redacted>
 version_created_at: 2017-01-01T04:07:18Z
 ```
 
@@ -55,10 +55,7 @@ user$ credhub generate --type user --name '/example-user'
 id: 67fc3def-bbfb-4953-83f8-4ab0682ad675
 name: /example-user
 type: user
-value:
-  username: FQnwWoxgSrDuqDLmeLpU
-  password: 6mRPZB3bAfb8lRpacnXsHfDhlPqFcjH2h9YDvLpL
-  password_hash: $6$h3b3JsG5$MnrPIrF6T3zAWk9uaun64vWY.vaBQ5nTRFZjjVqKuDWccxWXn8n6vstQykXEReamb4GYh2q1HC7vFy11wflXd0
+value: <redacted>
 version_created_at: 2017-01-01T04:07:18Z
 ```
 
@@ -73,19 +70,7 @@ user$ credhub generate --type certificate --name '/example-certificate' --common
 id: 67fc3def-bbfb-4953-83f8-4ab0682ad675
 name: /example-certificate
 type: certificate
-value:
-  root: |
-    -----BEGIN CERTIFICATE-----
-    ...
-    -----END CERTIFICATE-----
-  certificate: |
-    -----BEGIN CERTIFICATE-----
-    ...
-    -----END CERTIFICATE-----
-  private_key: |
-    -----BEGIN RSA PRIVATE KEY-----
-    ...
-    -----END RSA PRIVATE KEY-----
+value: <redacted>
 version_created_at: 2017-01-01T04:07:18Z
 ```
 
@@ -100,15 +85,7 @@ user$ credhub generate --type rsa --name '/example-rsa'
 id: 67fc3def-bbfb-4953-83f8-4ab0682ad675
 name: /example-rsa
 type: rsa
-value:
-  public_key: |
-    -----BEGIN PUBLIC KEY-----
-    ...
-    -----END PUBLIC KEY-----
-  private_key: |
-    -----BEGIN RSA PRIVATE KEY-----
-    ...
-    -----END RSA PRIVATE KEY-----
+value: <redacted>
 version_created_at: 2017-01-01T04:07:18Z
 ```
 
@@ -124,12 +101,7 @@ user$ credhub generate --type ssh --name '/example-ssh'
 id: 67fc3def-bbfb-4953-83f8-4ab0682ad675
 name: /example-ssh
 type: ssh
-value:
-  public_key: ssh-rsa AAAAB3NzaC1y...W9RWFM1
-  private_key: |
-    -----BEGIN RSA PRIVATE KEY-----
-    ...
-    -----END RSA PRIVATE KEY-----
+value: <redacted>
 version_created_at: 2017-01-01T04:07:18Z
 ```
 

--- a/includes/_cli-regenerate.md
+++ b/includes/_cli-regenerate.md
@@ -17,7 +17,7 @@ user$ credhub regenerate --name '/example-password'
 id: 67fc3def-bbfb-4953-83f8-4ab0682ad675
 name: /example-password
 type: password
-value: 3t6Y2OFP0jQIcLnki1h7p3NtSfDx4l9bamr1ja6R
+value: <redacted>
 version_created_at: 2017-01-01T04:07:18Z
 ```
 

--- a/includes/_cli-set.md
+++ b/includes/_cli-set.md
@@ -26,7 +26,7 @@ user$ credhub set --type value --name '/example-value' --password 'sample'
 id: 67fc3def-bbfb-4953-83f8-4ab0682ad675
 name: /example-value
 type: value
-value: sample
+value: <redacted>
 version_created_at: 2017-01-01T04:07:18Z
 ```
 
@@ -43,12 +43,7 @@ user$ credhub set --type json --name '/example-json' --value '{ "key": 123, "key
 id: 67fc3def-bbfb-4953-83f8-4ab0682ad675
 name: /example-json
 type: json
-value:
-  key: 123
-  key_list:
-  - val1
-  - val2
-  is_true: true
+value: <redacted>
 version_created_at: 2017-01-01T04:07:18Z
 ```
 
@@ -65,7 +60,7 @@ user$ credhub set --type password --name '/example-password' --password '3t6Y2OF
 id: 67fc3def-bbfb-4953-83f8-4ab0682ad675
 name: /example-password
 type: password
-value: 3t6Y2OFP0jQIcLnki1h7p3NtSfDx4l9bamr1ja6R
+value: <redacted>
 version_created_at: 2017-01-01T04:07:18Z
 ```
 
@@ -82,10 +77,7 @@ user$ credhub set --type user --name '/example-user' --username 'FQnwWoxgSrDuqDL
 id: 67fc3def-bbfb-4953-83f8-4ab0682ad675
 name: /example-user
 type: user
-value:
-  username: FQnwWoxgSrDuqDLmeLpU
-  password: 6mRPZB3bAfb8lRpacnXsHfDhlPqFcjH2h9YDvLpL
-  password_hash: $6$h3b3JsG5$MnrPIrF6T3zAWk9uaun64vWY.vaBQ5nTRFZjjVqKuDWccxWXn8n6vstQykXEReamb4GYh2q1HC7vFy11wflXd0
+value: <redacted>
 version_created_at: 2017-01-01T04:07:18Z
 ```
 
@@ -102,19 +94,7 @@ user$ credhub set --type certificate --name '/example-certificate' --root ./root
 id: 67fc3def-bbfb-4953-83f8-4ab0682ad675
 name: /example-certificate
 type: certificate
-value:
-  root: |
-    -----BEGIN CERTIFICATE-----
-    ...
-    -----END CERTIFICATE-----
-  certificate: |
-    -----BEGIN CERTIFICATE-----
-    ...
-    -----END CERTIFICATE-----
-  private_key: |
-    -----BEGIN RSA PRIVATE KEY-----
-    ...
-    -----END RSA PRIVATE KEY-----
+value: <redacted>
 version_created_at: 2017-01-01T04:07:18Z
 ```
 
@@ -131,15 +111,7 @@ user$ credhub set --type rsa --name '/example-rsa' --public ./public.pem --priva
 id: 67fc3def-bbfb-4953-83f8-4ab0682ad675
 name: /example-rsa
 type: rsa
-value:
-  public_key: |
-    -----BEGIN PUBLIC KEY-----
-    ...
-    -----END PUBLIC KEY-----
-  private_key: |
-    -----BEGIN RSA PRIVATE KEY-----
-    ...
-    -----END RSA PRIVATE KEY-----
+value: <redacted>
 version_created_at: 2017-01-01T04:07:18Z
 ```
 
@@ -156,12 +128,7 @@ user$ credhub set --type ssh --name '/example-ssh' --public ./public.pem --priva
 id: 67fc3def-bbfb-4953-83f8-4ab0682ad675
 name: /example-ssh
 type: ssh
-value:
-  public_key: ssh-rsa AAAAB3NzaC1y...W9RWFM1
-  private_key: |
-    -----BEGIN RSA PRIVATE KEY-----
-    ...
-    -----END RSA PRIVATE KEY-----
+value: <redacted>
 version_created_at: 2017-01-01T04:07:18Z
 ```
 


### PR DESCRIPTION
The `generate`, `regenerate`, and `set` subcommands of the CredHub CLI
always redact the value of the credential. This updates the CLI docs to
reflect that.

See:
https://github.com/cloudfoundry-incubator/credhub-cli/blob/03ba1c405d5eacaae2bd00eba6dcf924ef7b866b/commands/generate.go#L122
https://github.com/cloudfoundry-incubator/credhub-cli/blob/03ba1c405d5eacaae2bd00eba6dcf924ef7b866b/commands/regenerate.go#L45
https://github.com/cloudfoundry-incubator/credhub-cli/blob/03ba1c405d5eacaae2bd00eba6dcf924ef7b866b/commands/set.go#L54

Co-authored-by: Pablo Rodas <prodas@vmware.com>